### PR TITLE
Replace direct child_process usage

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -1,7 +1,8 @@
-const CP = require('child_process')
+const Spawn = require('./spawn')
 
-module.exports = function (options, done) {
-  var proc = CP.spawn('git', ['add', 'package.json'])
+module.exports = function (done) {
+  var cmd = 'git'
+  var args = ['add', 'package.json']
 
-  proc.on('exit', done)
+  Spawn(cmd, args, {}, done)
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,7 +1,8 @@
-const CP = require('child_process')
+const Spawn = require('./spawn')
 
 module.exports = function (module, options, done) {
-  var proc = CP.spawn('npm', ['install', module].concat(options))
+  var cmd = 'npm'
+  var args = ['install', module].concat(options)
 
-  proc.on('exit', done)
+  Spawn(cmd, args, {}, done)
 }

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,0 +1,14 @@
+const Util = require('util')
+
+const Assign = require('lodash.assign')
+const WinSpawn = require('win-spawn')
+
+module.exports = function (command, args, opts, done) {
+  var child = WinSpawn(command, args, Assign({ stdio: 'inherit' }, opts))
+
+  child.on('error', done)
+  child.on('close', function (code) {
+    if (code === 0) done()
+    else done(new Error(Util.format('non-zero exit code: %s', code)))
+  })
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "standard": "~5.3.1"
   },
   "dependencies": {
+    "lodash.assign": "3.2.0",
     "run-series": "1.1.4",
     "win-spawn": "2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "standard": "~5.3.1"
   },
   "dependencies": {
-    "run-series": "1.1.4"
+    "run-series": "1.1.4",
+    "win-spawn": "2.0.0"
   }
 }

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -1,0 +1,83 @@
+const Events = require('events')
+
+const Code = require('code')
+const Lab = require('lab')
+const Proxyquire = require('proxyquire')
+const Sinon = require('sinon')
+
+var cp = new Events.EventEmitter()
+var winSpawn = Sinon.stub().returns(cp)
+
+const Spawn = Proxyquire('../lib/spawn', {
+  'win-spawn': winSpawn
+})
+
+var lab = exports.lab = Lab.script()
+
+var describe = lab.describe
+var it = lab.it
+var beforeEach = lab.beforeEach
+var afterEach = lab.afterEach
+var expect = Code.expect
+
+afterEach(function (done) {
+  winSpawn.reset()
+  cp.removeAllListeners()
+  done()
+})
+
+describe('spawn', () => {
+  var cmd, args, options
+
+  beforeEach((done) => {
+    cmd = 'test'
+    args = ['arg1', 'arg2']
+    options = { cwd: '/tmp', stdio: 'ignore' }
+    done()
+  })
+
+  it('exports a function', (done) => {
+    expect(Spawn).to.be.a.function()
+    done()
+  })
+
+  it('spawns a child with passed params', function (done) {
+    Spawn(cmd, args, options, function () {
+      expect(winSpawn.calledWith(cmd, args, options)).to.be.true()
+      done()
+    })
+    cp.emit('close', 0)
+  })
+
+  it('sets stdio to inherit if not present', function (done) {
+    delete options.stdio
+    Spawn(cmd, args, options, function () {
+      expect(winSpawn.lastCall.args[2].cwd).to.equal('/tmp')
+      expect(winSpawn.lastCall.args[2].stdio).to.equal('inherit')
+      done()
+    })
+    cp.emit('close', 0)
+  })
+
+  describe('when the child process errors', function () {
+    it('yields the error', function (done) {
+      var error = new Error('cp err')
+      Spawn(cmd, args, options, function (err) {
+        expect(err).to.equal(error)
+        done()
+      })
+      cp.emit('error', error)
+    })
+  })
+
+  describe('when the child exits non-zero', function () {
+    it('yields an error', function (done) {
+      Spawn(cmd, args, options, function (err) {
+        expect(err).to.be.instanceOf(Error)
+        expect(err.message).to.equal('non-zero exit code: 1')
+        done()
+      })
+      cp.emit('close', 1)
+    })
+  })
+})


### PR DESCRIPTION
Wrap all child process interfaces with calls to [`win-spawn`](https://www.npmjs.com/package/win-spawn)
